### PR TITLE
feat: change Todo and Category relationship to many-to-many

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1227,9 +1227,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
+      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/server/prisma/migrations/20250130081415_change_todo_category_relation_many_to_many/migration.sql
+++ b/server/prisma/migrations/20250130081415_change_todo_category_relation_many_to_many/migration.sql
@@ -1,0 +1,32 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `categoryId` on the `Todo` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Todo" DROP CONSTRAINT "Todo_categoryId_fkey";
+
+-- AlterTable
+ALTER TABLE "Category" ALTER COLUMN "updatedAt" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Todo" DROP COLUMN "categoryId",
+ALTER COLUMN "updatedAt" DROP NOT NULL;
+
+-- CreateTable
+CREATE TABLE "_CategoryToTodo" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+
+    CONSTRAINT "_CategoryToTodo_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "_CategoryToTodo_B_index" ON "_CategoryToTodo"("B");
+
+-- AddForeignKey
+ALTER TABLE "_CategoryToTodo" ADD CONSTRAINT "_CategoryToTodo_A_fkey" FOREIGN KEY ("A") REFERENCES "Category"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_CategoryToTodo" ADD CONSTRAINT "_CategoryToTodo_B_fkey" FOREIGN KEY ("B") REFERENCES "Todo"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/migrations/20250131022606_add_todo_category/migration.sql
+++ b/server/prisma/migrations/20250131022606_add_todo_category/migration.sql
@@ -1,0 +1,34 @@
+/*
+  Warnings:
+
+  - You are about to drop the `_CategoryToTodo` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "_CategoryToTodo" DROP CONSTRAINT "_CategoryToTodo_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_CategoryToTodo" DROP CONSTRAINT "_CategoryToTodo_B_fkey";
+
+-- DropTable
+DROP TABLE "_CategoryToTodo";
+
+-- CreateTable
+CREATE TABLE "TodoCategory" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3),
+    "todoId" INTEGER NOT NULL,
+    "categoryId" INTEGER NOT NULL,
+
+    CONSTRAINT "TodoCategory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TodoCategory_todoId_categoryId_key" ON "TodoCategory"("todoId", "categoryId");
+
+-- AddForeignKey
+ALTER TABLE "TodoCategory" ADD CONSTRAINT "TodoCategory_todoId_fkey" FOREIGN KEY ("todoId") REFERENCES "Todo"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TodoCategory" ADD CONSTRAINT "TodoCategory_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/migrations/20250131061311_add_id_to_todo_category/migration.sql
+++ b/server/prisma/migrations/20250131061311_add_id_to_todo_category/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `updatedAt` on the `TodoCategory` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "TodoCategory" DROP COLUMN "updatedAt";

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -12,16 +12,30 @@ model Todo {
   id Int @id @default(autoincrement())
   title String
   isCompleted Boolean @default(false)
-  categoryId Int
-  category Category @relation(fields: [categoryId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime? @updatedAt
+
+  todoCategories TodoCategory[]
 }
 
 model Category {
   id Int @id @default(autoincrement())
   name String
-  todos Todo[]
   createdAt DateTime @default(now())
   updatedAt DateTime? @updatedAt
+
+  todoCategories TodoCategory[]
+}
+
+model TodoCategory {
+  id Int @id @default(autoincrement())
+  createdAt DateTime @default(now())
+
+  todoId Int
+  categoryId Int
+
+  todo Todo @relation(fields: [todoId], references: [id])
+  category Category @relation(fields: [categoryId], references: [id])
+
+  @@unique([todoId, categoryId])
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -19,17 +19,27 @@ app.get("/allTodos", async (req: Request, res: Response) => {
   try {
     const todos = await prisma.todo.findMany({
       include: {
-        category: true,
+        todoCategories: {
+          include: {
+            category: true,
+          },
+        },
       },
     });
 
-    res.json(todos.map(todo => ({
+    const result = todos.map((todo) => ({
       id: todo.id,
       title: todo.title,
       isCompleted: todo.isCompleted,
-      category: { id: todo.categoryId, name: todo.category.name }
-    })));
+      categories: (todo.todoCategories ?? [])
+        .map((tc: {category: { id: number; name: string } }) => ({
+          id: tc.category.id,
+          name: tc.category.name,
+        }))
+        .sort((a,b) => a.id - b.id),
+    }));
 
+    res.json(result)
   } catch (error) {
     console.error(error);
     res.status(500).json({error: "Failed to fetch todos" })
@@ -37,28 +47,40 @@ app.get("/allTodos", async (req: Request, res: Response) => {
 });
 
 app.post("/createTodo", async (req: Request, res: Response) => {
-  console.log(req.body);
-
   try {
     const {
       title,
       isCompleted,
-      categoryId
+      categoryIds
     } = req.body;
 
     const createTodo = await prisma.todo.create({
       data: {
         title,
         isCompleted,
-        category: {
-          connect: {
-            id: categoryId,
-          }
-        }
-      }
+      },
     });
+
+    await prisma.todoCategory.createMany({
+      data: categoryIds.map((id: number) => ({
+        todoId: createTodo.id,
+        categoryId: id,
+      })),
+    });
+
+    const updatedTodo = await prisma.todo.findUnique({
+      where: { id: createTodo.id },
+      include: {
+        todoCategories: {
+          include: { category: true },
+        },
+      },
+    });
+
+
     return res.json(createTodo);
   } catch(e) {
+    console.error(e);
     return res.status(400).json(e);
   }
 });
@@ -66,16 +88,37 @@ app.post("/createTodo", async (req: Request, res: Response) => {
 app.put("/editTodo/:id", async (req: Request, res: Response) => {
   try {
     const id = Number(req.params.id);
-    const { title, isCompleted } = req.body;
+    const {
+      title,
+      isCompleted,
+      categoryIds
+    } = req.body;
+
+    await prisma.todoCategory.deleteMany({
+      where: { todoId: id },
+    })
+
     const editTodo = await prisma.todo.update({
       where: { id },
       data: {
         title,
         isCompleted,
+        todoCategories: {
+          create: categoryIds.map((catId: number) => ({
+            category: { connect: { id: catId }},
+          })),
+        },
+      },
+      include: {
+        todoCategories: {
+          include: {category: true},
+        },
       },
     });
+
     return res.json(editTodo);
   } catch(e) {
+    console.error(e);
     return res.status(400).json(e);
   }
 });
@@ -88,6 +131,7 @@ app.delete("/deleteTodo/:id", async (req: Request, res: Response) => {
     });
     return res.json(deleteTodo);
   } catch(e) {
+    console.error(e);
     return res.status(400).json(e);
   }
 });

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -11,7 +11,6 @@
     "outDir": "./dist"
   },
   "include": [
-    "node_modules/@prisma/client/index.d.ts",
     "prisma/seeds/**/*.ts",
     "src/**/*.ts"
   ],


### PR DESCRIPTION
## チケットNo.
2200


## 概要

- カテゴリーテーブルの改修
TodoとCategoryの関連性を多対多に変更


## 影響範囲と影響度
Todoリスト


## テスト項目
- [x] レスポンス表示
```
categories: [
   {
       id: string
       name: string
   }
   {
       id: string
       name: string
   }
]
```


## レビューしてほしいポイント
- 多対多の実装


## 検証画像

![検証画像](https://github.com/user-attachments/assets/3177a855-f100-4e50-834d-2d51260b286b)


---

よろしくお願いいたします！