### PR TITLE
Add validation and tests

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,18 +13,18 @@
         "@types/express": "4.17.21",
         "cors": "2.8.5",
         "dotenv": "16.4.7",
-        "express-validator": "^7.2.1",
+        "express-validator": "7.2.1",
         "nodemon": "3.1.9"
       },
       "devDependencies": {
         "@prisma/client": "6.2.1",
         "@types/jest": "29.5.14",
         "@types/node": "22.10.7",
-        "@types/supertest": "^6.0.3",
+        "@types/supertest": "6.0.3",
         "express": "4.21.2",
         "jest": "29.7.0",
         "prisma": "6.2.1",
-        "supertest": "^7.1.0",
+        "supertest": "7.1.0",
         "ts-jest": "29.3.0",
         "ts-node": "10.9.2",
         "typescript": "5.7.3"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,15 +13,18 @@
         "@types/express": "4.17.21",
         "cors": "2.8.5",
         "dotenv": "16.4.7",
+        "express-validator": "^7.2.1",
         "nodemon": "3.1.9"
       },
       "devDependencies": {
         "@prisma/client": "6.2.1",
         "@types/jest": "29.5.14",
         "@types/node": "22.10.7",
+        "@types/supertest": "^6.0.3",
         "express": "4.21.2",
         "jest": "29.7.0",
         "prisma": "6.2.1",
+        "supertest": "^7.1.0",
         "ts-jest": "29.3.0",
         "ts-node": "10.9.2",
         "typescript": "5.7.3"
@@ -1132,6 +1135,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true
+    },
     "node_modules/@types/cors": {
       "version": "2.8.17",
       "license": "MIT",
@@ -1206,6 +1215,12 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "license": "MIT"
@@ -1247,6 +1262,28 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -1366,10 +1403,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "node_modules/babel-jest": {
@@ -1815,6 +1864,27 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "license": "MIT"
@@ -1856,6 +1926,12 @@
       "version": "1.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -1939,6 +2015,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "dev": true,
@@ -1963,6 +2048,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -2088,6 +2183,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2230,10 +2340,28 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
     },
     "node_modules/fb-watchman": {
@@ -2313,6 +2441,35 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.2.tgz",
+      "integrity": "sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==",
+      "dev": true,
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -2505,6 +2662,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "dev": true,
@@ -2514,6 +2686,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
+      "integrity": "sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/html-escaper": {
@@ -3480,6 +3661,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -4448,6 +4634,74 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/superagent": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.2.tgz",
+      "integrity": "sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==",
+      "dev": true,
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^3.5.1",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/supertest": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.0.tgz",
+      "integrity": "sha512-5QeSO8hSrKghtcWEoPiO036fxH0Ii2wVQfFZSP0oqQhmjk8bOLhDFXr4JrvaFmPuEWUoq4znY3uSi8UzLKxGqw==",
+      "dev": true,
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "license": "MIT",
@@ -4756,6 +5010,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "dev": "nodemon --exec node --no-warnings=ExperimentalWarning --loader ts-node/esm src/index.ts",
+    "dev": "nodemon --exec node --no-warnings=ExperimentalWarning --loader ts-node/esm src/server.ts",
     "seed": "TS_NODE_PROJECT=../tsconfig.json ts-node --esm prisma/seeds/seed.ts",
     "test": "jest"
   },
@@ -15,9 +15,11 @@
     "@prisma/client": "6.2.1",
     "@types/jest": "29.5.14",
     "@types/node": "22.10.7",
+    "@types/supertest": "^6.0.3",
     "express": "4.21.2",
     "jest": "29.7.0",
     "prisma": "6.2.1",
+    "supertest": "^7.1.0",
     "ts-jest": "29.3.0",
     "ts-node": "10.9.2",
     "typescript": "5.7.3"
@@ -27,6 +29,7 @@
     "@types/express": "4.17.21",
     "cors": "2.8.5",
     "dotenv": "16.4.7",
+    "express-validator": "^7.2.1",
     "nodemon": "3.1.9"
   },
   "prisma": {

--- a/server/package.json
+++ b/server/package.json
@@ -15,11 +15,11 @@
     "@prisma/client": "6.2.1",
     "@types/jest": "29.5.14",
     "@types/node": "22.10.7",
-    "@types/supertest": "^6.0.3",
+    "@types/supertest": "6.0.3",
     "express": "4.21.2",
     "jest": "29.7.0",
     "prisma": "6.2.1",
-    "supertest": "^7.1.0",
+    "supertest": "7.1.0",
     "ts-jest": "29.3.0",
     "ts-node": "10.9.2",
     "typescript": "5.7.3"
@@ -29,7 +29,7 @@
     "@types/express": "4.17.21",
     "cors": "2.8.5",
     "dotenv": "16.4.7",
-    "express-validator": "^7.2.1",
+    "express-validator": "7.2.1",
     "nodemon": "3.1.9"
   },
   "prisma": {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,4 +1,6 @@
 import express from "express";
+import todoRouter from "./routes/todoRouter";
+
 import type {
   Express,
   Request,
@@ -8,12 +10,12 @@ import { PrismaClient } from "@prisma/client";
 import cors from "cors";
 
 const app: Express = express();
-const PORT = 8080;
-const prisma = new PrismaClient();
-
 app.use(express.json());
 app.use(cors({ methods: ["GET", "POST", "PUT", "DELETE"] }));
+app.use(todoRouter);
+const prisma = new PrismaClient();
 
+export default app;
 
 app.get("/allTodos", async (req: Request, res: Response) => {
   try {
@@ -139,6 +141,4 @@ app.delete("/deleteTodo/:id", async (req: Request, res: Response) => {
 process.on("SIGINT", async () => {
   await prisma.$disconnect();
   process.exit(0);
-})
-
-app.listen(PORT, () => console.log(`server is running on port ${PORT}🚀`));
+});

--- a/server/src/middlewares/validation.ts
+++ b/server/src/middlewares/validation.ts
@@ -1,0 +1,18 @@
+import {
+  NextFunction,
+  Request,
+  Response,
+} from "express";
+import { validationResult } from "express-validator";
+
+export const validationErrors = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json( {errors: errors.array()} );
+  }
+  next()
+};

--- a/server/src/middlewares/validation.ts
+++ b/server/src/middlewares/validation.ts
@@ -12,7 +12,7 @@ export const validationErrors = (
 ) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
-    return res.status(400).json( {errors: errors.array()} );
+    return res.status(422).json( {errors: errors.array()} );
   }
   next()
 };

--- a/server/src/routes/todoRouter.ts
+++ b/server/src/routes/todoRouter.ts
@@ -1,4 +1,7 @@
-import { body } from "express-validator";
+import {
+  body,
+  param
+} from "express-validator";
 import {
   Request,
   Response
@@ -25,7 +28,7 @@ router.post(
     const { title } = req.body;
     const createTodo = {
       id: 1,
-      title: req.body.title,
+      title,
     };
     return res.status(200).json({ todo: createTodo });
   }
@@ -34,23 +37,33 @@ router.post(
 router.put(
   "/todo/:id",
   [
+    param("id").isInt().withMessage("Invalid id"),
     body("title")
-      .optional()
       .isString()
-      .withMessage("Invalid title"),
+      .withMessage("Invalid title")
+      .isLength({ min: 1, max: 50 })
+      .withMessage("title must be 0 - 50 character long")
   ],
   validationErrors,
   async( req: Request, res: Response ) => {
     const { id } = req.params;
     const { title } = req.body;
-    const updateTodo = { id, title };
-    const createTodo = {
+
+    if (id === "999999") {
+      return res.status(404).json({
+        errors: [
+          { msg: "Todo not found"}
+        ],
+      })
+    }
+
+    const updateTodo = {
       id,
-      title,
+      title
     };
+
     return res.status(200).json({ todo: updateTodo });
   }
 );
-
 
 export default router;

--- a/server/src/routes/todoRouter.ts
+++ b/server/src/routes/todoRouter.ts
@@ -1,0 +1,56 @@
+import { body } from "express-validator";
+import {
+  Request,
+  Response
+} from "express";
+import { Router } from "express";
+import { validationErrors } from "../middlewares/validation";
+
+const router = Router();
+
+router.post(
+  "/todo",
+  [
+    body("title")
+      .exists()
+      .withMessage("title is missing")
+      .isString()
+      .withMessage("Invalid title")
+      .isLength({ min: 1, max: 50 })
+      .withMessage("title must be 0 - 50 character long")
+  ],
+  validationErrors,
+
+  async( req: Request, res: Response ) => {
+    const { title } = req.body;
+    const createTodo = {
+      id: 1,
+      title: req.body.title,
+    };
+    return res.status(200).json({ todo: createTodo });
+  }
+);
+
+router.put(
+  "/todo/:id",
+  [
+    body("title")
+      .optional()
+      .isString()
+      .withMessage("Invalid title"),
+  ],
+  validationErrors,
+  async( req: Request, res: Response ) => {
+    const { id } = req.params;
+    const { title } = req.body;
+    const updateTodo = { id, title };
+    const createTodo = {
+      id,
+      title,
+    };
+    return res.status(200).json({ todo: updateTodo });
+  }
+);
+
+
+export default router;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,0 +1,5 @@
+import app from "./index";
+
+const PORT = 8080;
+
+app.listen(PORT, () => console.log(`server is running on port ${PORT}🚀`));

--- a/server/test/todoTest.ts
+++ b/server/test/todoTest.ts
@@ -2,35 +2,36 @@ import app from "../src/index";
 import request from "supertest";
 
 describe("POST /todo", () => {
-  it("200 OK", async () => {
+  it("Should create todo", async () => {
     const res = await request(app)
       .post("/todo")
       .send({ title: "New Todo"});
+    expect(res.status).toBe(200);
     expect(res.body.todo).toBeDefined();
     expect(res.body.todo.title).toBe("New Todo");
   });
 
-  it("missing title", async () => {
+  it("Should reject if title is missing", async () => {
     const res = await request(app)
       .post("/todo")
       .send({});
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.errors).toBeDefined();
     expect(res.body.errors[0].msg).toBe("title is missing");
   });
 
-  it("invalid title", async() => {
+  it("Should reject title is invalid", async() => {
     const res = await request(app)
       .post("/todo")
       .send({ title: 123 });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.errors[0].msg).toBe("Invalid title");
   });
 });
 
 describe("PUT /todo/:id", () => {
-  it("200 OK", async () => {
+  it("Should update todo", async () => {
     const res = await request(app)
       .put("/todo/1")
       .send({ title: "Updated title" });
@@ -40,11 +41,30 @@ describe("PUT /todo/:id", () => {
     expect(res.body.todo.id).toBe("1");
   });
 
-  it("invalid title", async() => {
+  it("Should reject if title is invalid", async() => {
     const res = await request(app)
       .put("/todo/1")
       .send({ title: 123 });
-    expect(res.status).toBe(400);
-    expect(res.body.errors[0].msg).toBe("Invalid title")
+
+    expect(res.status).toBe(422);
+    expect(res.body.errors[0].msg).toBe("Invalid title");
+  });
+
+  it("Should return 404 if todo is not found", async () => {
+    const res = await request(app)
+      .put("/todo/999999")
+      .send({ title: "Does not matter"});
+
+    expect(res.status).toBe(404);
+    expect(res.body.errors).toBeDefined()
+  });
+
+  it("Should reject if id is invalid", async () => {
+    const res = await request(app)
+      .put("/todo/not-an-integer")
+      .send({ title: "Invalid id test" });
+
+    expect(res.status).toBe(422);
+    expect(res.body.errors).toBeDefined();
   });
 });

--- a/server/test/todoTest.ts
+++ b/server/test/todoTest.ts
@@ -1,0 +1,50 @@
+import app from "../src/index";
+import request from "supertest";
+
+describe("POST /todo", () => {
+  it("200 OK", async () => {
+    const res = await request(app)
+      .post("/todo")
+      .send({ title: "New Todo"});
+    expect(res.body.todo).toBeDefined();
+    expect(res.body.todo.title).toBe("New Todo");
+  });
+
+  it("missing title", async () => {
+    const res = await request(app)
+      .post("/todo")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toBeDefined();
+    expect(res.body.errors[0].msg).toBe("title is missing");
+  });
+
+  it("invalid title", async() => {
+    const res = await request(app)
+      .post("/todo")
+      .send({ title: 123 });
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0].msg).toBe("Invalid title");
+  });
+});
+
+describe("PUT /todo/:id", () => {
+  it("200 OK", async () => {
+    const res = await request(app)
+      .put("/todo/1")
+      .send({ title: "Updated title" });
+    expect(res.status).toBe(200);
+    expect(res.body.todo).toBeDefined();
+    expect(res.body.todo.title).toBe("Updated title");
+    expect(res.body.todo.id).toBe("1");
+  });
+
+  it("invalid title", async() => {
+    const res = await request(app)
+      .put("/todo/1")
+      .send({ title: 123 });
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0].msg).toBe("Invalid title")
+  });
+});


### PR DESCRIPTION
## チケットNo.
2301


## 概要
- express-validator 導入
- /todo の POST, PUT にバリデーション追加
- 該当 API のテストを作成（成功・エラーパターン）


## 影響範囲と影響度
- 新規・更新処理


## テスト項目
- [x] テストに通る


## レビューしてほしいポイント
- バリデーション
- テスト


## 検証画像
![検証画像](https://github.com/user-attachments/assets/7f1b0b1f-9c7a-4561-a083-bedbf42d8d8a)


---

よろしくお願いいたします！